### PR TITLE
Remove CryptomatteInfo metatable

### DIFF
--- a/fusion/Fuses/Matte/cryptomatte.fuse
+++ b/fusion/Fuses/Matte/cryptomatte.fuse
@@ -7,44 +7,65 @@ Created by : Cédric Duriau         [duriau.cedric@live.be]
 Version    : 1.2.8
 --]]
 
--- =============================================================================
+-- ============================================================================
 -- modules
--- =============================================================================
+-- ============================================================================
 local cryptoutils = self and require("cryptomatte_utilities") or nil
 
--- =============================================================================
+-- ============================================================================
 -- constants
--- =============================================================================
+-- ============================================================================
 FUSE_NAME = "Cryptomatte"
 FUSE_CATEGORY = "Matte"
 FUSE_COMPANY = "Psyop"
 FUSE_HELP = "https://www.steakunderwater.com/wesuckless/viewtopic.php?f=6&t=1027"
 FUSE_URL = "https://github.com/Psyop/Cryptomatte"
-FUSE_VERSION = 121
+FUSE_VERSION = 128
 
-SEPARATOR = string.rep("_", 9999)
-SEPARATOR_INDEX = 0
-SHOW_CALLBACKS = false
+SEPARATOR_INDEX = 1
 VIEW_MODE_EDGES = "Edges"
 VIEW_MODE_COLORS = "Colors"
 VIEW_MODE_NONE = "None"
 VIEW_MODES = {VIEW_MODE_EDGES, VIEW_MODE_COLORS, VIEW_MODE_NONE}
+SHOW_CALLBACKS = true
 
--- =============================================================================
+
+-- ============================================================================
+-- utils
+-- ============================================================================
+function create_separator()
+    --[[
+    Creates a separator input control.
+
+    :rtype: Input
+    ]]
+    SEPARATOR_INDEX = SEPARATOR_INDEX + 1
+    return self:AddInput("Separator" , string.format("Separator%s", SEPARATOR_INDEX) , {
+        INPID_InputControl = "SeparatorControl",
+        IC_Visible = true,
+        INP_External = false,
+        INP_Passive = true
+    })
+end
+
+
+-- ============================================================================
 -- fuse
--- =============================================================================
-FuRegisterClass(FUSE_NAME, CT_Tool, {REGS_Name = FUSE_NAME,
-                                     REGS_Category = FUSE_CATEGORY,
-                                     REGS_Company = FUSE_COMPANY,
-                                     REGS_OpIconString = FUSE_NAME,
-                                     REGS_OpDescription = FUSE_NAME,
-                                     REGS_URL = FUSE_URL,
-                                     REGS_HelpTopic = FUSE_HELP,
-                                     REG_NoMotionBlurCtrls = true,
-                                     REG_NoBlendCtrls = true,
-                                     REG_OpNoMask = true,
-                                     REG_Version = FUSE_VERSION,
-                                     REG_SupportsDoD = true})
+-- ============================================================================
+FuRegisterClass(FUSE_NAME, CT_Tool, {
+    REGS_Name = FUSE_NAME,
+    REGS_Category = FUSE_CATEGORY,
+    REGS_Company = FUSE_COMPANY,
+    REGS_OpIconString = FUSE_NAME,
+    REGS_OpDescription = FUSE_NAME,
+    REGS_URL = FUSE_URL,
+    REGS_HelpTopic = FUSE_HELP,
+    REG_NoMotionBlurCtrls = true,
+    REG_NoBlendCtrls = true,
+    REG_OpNoMask = true,
+    REG_Version = FUSE_VERSION,
+    REG_SupportsDoD = true
+})
 
 function Create()
     --[[ Creates the user interface. ]]
@@ -53,34 +74,38 @@ function Create()
         LINKID_DataType = "Image",
         LINK_Main = 1
     })
+
     -- output
     OutImage = self:AddOutput("Output", "Output", {
         LINKID_DataType = "Image",
         LINK_Main = 1
     })
 
-    -- locator & picking
-    Locator = self:AddInput("Locator", "Locator", {
+    -- locator
+    LocatorMatte = self:AddInput("Locator", "Locator", {
         LINKID_DataType = "Point",
         INPID_InputControl = "OffsetControl",
         INPID_PreviewControl = "CrosshairControl",
         ICS_Name = "Matte Locator"
     })
-    BtnAdd = self:AddInput("Add", "Add", {
+
+    ButtonAdd = self:AddInput("Add", "Add", {
         LINKID_DataType = "Number",
         INPID_InputControl = "ButtonControl",
         INP_External = false,
         INP_DoNotifyChanged = true,
         ICD_Width = 1 / 3
     })
-    BtnRemove = self:AddInput("Remove", "Remove", {
+
+    ButtonRemove = self:AddInput("Remove", "Remove", {
         LINKID_DataType = "Number",
         INPID_InputControl = "ButtonControl",
         INP_External = false,
         INP_DoNotifyChanged = true,
         ICD_Width = 1 / 3
     })
-    BtnToggle= self:AddInput("Toggle", "Toggle", {
+
+    ButtonToggle = self:AddInput("Toggle", "Toggle", {
         LINKID_DataType = "Number",
         INPID_InputControl = "ButtonControl",
         INP_External = false,
@@ -90,14 +115,15 @@ function Create()
 
     create_separator()
 
-    -- view modes
-    CbPreview = self:AddInput("Keyable Surface", "KeyableSurface", {
+    -- preview
+    CheckboxViewMode = self:AddInput("Keyable Surface", "KeyableSurface", {
         LINKID_DataType = "Number",
         INPID_InputControl = "CheckboxControl",
         INP_Integer = true,
         INP_Default = 0.0,
         ICD_Width = 0.5
     })
+
     ComboViewMode = self:AddInput("", "ViewMode", {
         LINKID_DataType = "Number",
         INPID_InputControl = "ComboControl",
@@ -109,12 +135,14 @@ function Create()
         { CCS_AddString = VIEW_MODES[3] },
         CC_LabelPosition = "Vertical"
     })
-    CbMatteOnly = self:AddInput("Matte Only", "MatteOnly", {
+
+    CheckboxMatteOnly = self:AddInput("Matte Only", "MatteOnly", {
         LINKID_DataType = "Number",
         INPID_InputControl = "CheckboxControl",
         INP_Integer = true,
         INP_Default = 0.0,
-        ICD_Width = 1 / 3
+        ICD_Width = 1 / 3,
+        INP_DoNotifyChanged = true
     })
 
     create_separator()
@@ -128,7 +156,8 @@ function Create()
         TEC_Wrap = false,
         TEC_DeferSetInputs = true
     })
-    BtnClear = self:AddInput("Clear", "Clear", {
+
+    ButtonClear = self:AddInput("Clear", "Clear", {
         LINKS_Name = "Clear",
         LINKID_DataType = "Number",
         INPID_InputControl = "ButtonControl",
@@ -136,6 +165,7 @@ function Create()
         ICD_Width = 0.5,
         INP_DoNotifyChanged = true
     })
+
 
     create_separator()
 
@@ -148,6 +178,7 @@ function Create()
         INP_MinAllowed = 1,
         INP_MaxAllowed = 100
     })
+
     TextCryptoLayer = self:AddInput("Crypto Layer", "CryptoLayer", {
         LINKS_Name = "",
         LINKID_DataType = "Text",
@@ -156,9 +187,12 @@ function Create()
         TEC_ReadOnly = true
     })
 
-    -- advanced tab
+    -- advanced
+    SeparatorCallbacks = create_separator()
+    SeparatorCallbacks:SetAttrs({ICS_ControlPage = "Advanced"})
+
     -- name checker
-    LocatorNameChecker = self:AddInput("Locator Name Checker", "LocatorNameChecker", {
+    LocatorName = self:AddInput("Locator Name Checker", "LocatorName", {
         LINKID_DataType = "Point",
         INPID_InputControl = "OffsetControl",
         INPID_PreviewControl = "CrosshairControl",
@@ -166,22 +200,25 @@ function Create()
         ICS_ControlPage = "Advanced",
         PC_Visible = false
     })
-    BtnShow = self:AddInput("Show", "Show", {
+
+    ButtonShow = self:AddInput("Show", "Show", {
         LINKID_DataType = "Number",
         INPID_InputControl = "ButtonControl",
         INP_External = false,
         INP_DoNotifyChanged = true,
         ICD_Width = 0.5
     })
-    BtnHide = self:AddInput("Hide", "Hide", {
+
+    ButtonHide = self:AddInput("Hide", "Hide", {
         LINKID_DataType = "Number",
         INPID_InputControl = "ButtonControl",
         INP_External = false,
         INP_DoNotifyChanged = true,
         ICD_Width = 0.5
     })
-    TextKeyedName = self:AddInput("Keyed Name", "KeyedName", {
-        LINKS_Name = "Keyed Name",
+
+    TextMatteName = self:AddInput("Matte Name", "MatteName", {
+        LINKS_Name = "Matte Name",
         LINKID_DataType = "Text",
         INPID_InputControl = "TextEditControl",
         TEC_Lines = 1,
@@ -189,36 +226,27 @@ function Create()
         TEC_ReadOnly = true
     })
 
-    -- GUI callbacks
-    SeparatorCallbacks = create_separator()
+    create_separator()
+
+    -- callbacks
     SeparatorCallbacks:SetAttrs({IC_Visible = SHOW_CALLBACKS})
+    CheckboxAdd = self:AddInput("Add Callback", "AddCallback", {
+        LINKID_DataType = "Number",
+        INPID_InputControl = "CheckboxControl",
+        INP_Integer = true,
+        INP_Default = 0.0,
+        IC_Visible = SHOW_CALLBACKS
+    })
 
-    -- callback connect
-    CallbackConnect = self:AddInput("Connect Callback", "ConnectCallback", {
+    CheckboxRemove = self:AddInput("Remove Callback", "RemoveCallback", {
         LINKID_DataType = "Number",
         INPID_InputControl = "CheckboxControl",
         INP_Integer = true,
         INP_Default = 0.0,
         IC_Visible = SHOW_CALLBACKS
     })
-    -- callback add
-    CallbackBtnAdd = self:AddInput("Add Callback", "AddCallback", {
-        LINKID_DataType = "Number",
-        INPID_InputControl = "CheckboxControl",
-        INP_Integer = true,
-        INP_Default = 0.0,
-        IC_Visible = SHOW_CALLBACKS
-    })
-    -- callback remove
-    CallbackBtnRemove = self:AddInput("Remove Callback", "RemoveCallback", {
-        LINKID_DataType = "Number",
-        INPID_InputControl = "CheckboxControl",
-        INP_Integer = true,
-        INP_Default = 0.0,
-        IC_Visible = SHOW_CALLBACKS
-    })
-    -- callback toggle
-    CallbackBtnToggle = self:AddInput("Toggle Callback", "ToggleCallback", {
+
+    CheckboxToggle = self:AddInput("Toggle Callback", "ToggleCallback", {
         LINKID_DataType = "Number",
         INPID_InputControl = "CheckboxControl",
         INP_Integer = true,
@@ -227,344 +255,6 @@ function Create()
     })
 end
 
--- =============================================================================
--- utils
--- =============================================================================
-function create_separator()
-    --[[
-    Creates a separator input control.
-
-    :rtype: Input
-    ]]
-    SEPARATOR_INDEX = SEPARATOR_INDEX + 1
-    return self:AddInput(SEPARATOR, string.format("Separator%s", SEPARATOR_INDEX), {
-        LINKID_DataType = "Text",
-        INPID_InputControl = "LabelControl",
-        INP_External = false,
-        INP_Passive = true
-    })
-end
-
-function get_selected_layer()
-    --[[
-    Gets the selected layer name prefix.
-
-    :rtype: string
-    ]]
-    return TextCryptoLayer:GetSource(0).Value
-end
-
-function get_matte_selection_string()
-    --[[
-    Gets the matte selection input string.
-
-    :rtype: string
-    ]]
-    local matte_selection = TextMatteList:GetSource(0).Value
-    if matte_selection == nil then
-        return ""
-    end
-    return matte_selection
-end
-
-function set_layer_selection_slider(cInfo, default_layer)
-    --[[
-    Sets the layer selection slider values.
-
-    :param cInfo: cryptomatte info object
-    :type: CryptomatteInfo
-
-    :param default_layer: layer to set as default and current value of the slider
-    :type default_layer: string
-    ]]
-    set_slider_attributes(SliderCryptoLayer, 1, cInfo.nr_of_metadata_layers)
-    local index = cInfo.layer_name_to_index[default_layer]
-    SliderCryptoLayer.SetSource(Number(index), 0, 0)
-end
-
-function set_layer_selection_display(cInfo)
-    --[[
-    Displays the layer name based on the current position of the layer slider.
-
-    :param cInfo: cryptomatte info object
-    :type cInfo: CryptomatteInfo
-    ]]
-    local slider_index = SliderCryptoLayer:GetSource(0).Value
-    local layer_name = cInfo.index_to_layer_name[slider_index]
-    local current_layer = get_selected_layer()
-    if current_layer ~= layer_name then
-        TextCryptoLayer:SetSource(Text(layer_name), 0, 0)
-    end
-end
-
-function set_slider_attributes(slider, min, max)
-    --[[
-    Sets the minimum and maximum range of the given slider.
-
-    :param min: minimum allowed range of the slider
-    :type min: float
-
-    :param max: maximum allowed range of the slider
-    :type max: float
-    ]]
-    slider:SetAttrs({INP_MinAllowed = min,
-                     INP_MaxAllowed = max,
-                     INP_MinScale = min,
-                     INP_MaxScale = max})
-end
-
-function update_matte_list(cInfo, matte_name, remove, toggle, matte_selection)
-    --[[
-    Updates the matte selection list based.
-
-    :param cInfo: cryptomatte info object
-    :type cInfo: CryptomatteInfo
-
-    :param matte_name: name of the matte to add or remove
-    :type matte_name: string
-
-    :param remove: If set to true, the matte_name will be removed from the
-                   matte selection string. If set to false, it will be added
-                   to the matte selection string.
-    :type remove: bool
-
-    :param toggle: Removes the matte name from the matte selection string if it
-                   is present, otherwise adds it to the matte selection string.
-    :type toggle: bool
-
-    :param matte_selection: current matte selection string to update
-    :type matte_selection: string
-
-    :return: updated matte selection string
-    :rtype: string
-    ]]
-    -- get valid matte names cross matches from manifest
-    local matte_set = cryptoutils:get_matte_names_from_selection(cInfo, matte_selection)
-
-    -- check if the matte to add/remove is present in the set
-    local matte_present = matte_set[matte_name]
-
-    if toggle then
-      -- toggle (add or remove) the matte from the set
-      if not matte_present then
-          matte_set[matte_name] = true
-      else
-          matte_set[matte_name] = nil
-      end
-    elseif remove then
-        -- remove matte from set
-        if matte_present then
-            matte_set[matte_name] = nil
-        else
-            return
-        end
-    else
-        -- add matte to set
-        if not matte_present then
-            matte_set[matte_name] = true
-        else
-            return
-        end
-    end
-
-    -- wrap matte names inside set with double string quotes
-    local new_content = {}
-    for matte_name, _ in pairs(matte_set) do
-        matte_name = "\"" .. matte_name .. "\""
-        table.insert(new_content, matte_name)
-    end
-
-    -- concatenate the set into a string
-    -- string concat .. operator allocates more memory than table.concat
-    -- https://stackoverflow.com/questions/1405583/concatenation-of-strings-in-lua
-    return table.concat(new_content, ", ")
-end
-
-function toggle_matte(cInfo, id_float_value, matte_selection)
-    --[[
-    Toggles (adds or removes) the matte with given id from the matte selection.
-
-    :param cInfo: cryptomatte info object
-    :type cInfo: CryptomatteInfo
-
-    :param id_float_value: id float value of the matte to toggle
-    :type id_float_value: CryptomatteInfo
-
-    :param matte_selection: current matte selection string to update
-    :type matte_selection: string
-    ]]
-    -- get matte name of id float value
-    local matte_name = cInfo.cryptomattes[cInfo.selection]["id_to_name"][id_float_value]
-    if not matte_name then
-        return
-    end
-
-    -- create an updated version of the matte list string
-    local new_matte_list = update_matte_list(cInfo, matte_name, false, true, matte_selection)
-    if new_matte_list ~= nil then
-        TextMatteList:SetSource(Text(new_matte_list), 0, 0)
-    end
-end
-
-function add_matte(cInfo, id_float_value, matte_selection)
-    --[[
-    Adds the matte with given id from the matte selection.
-
-    :param cInfo: cryptomatte info object
-    :type cInfo: CryptomatteInfo
-
-    :param id_float_value: id float value of the matte to add
-    :type id_float_value: CryptomatteInfo
-
-    :param matte_selection: current matte selection string to update
-    :type matte_selection: string
-    ]]
-    -- get matte name of id float value
-    local matte_name = cInfo.cryptomattes[cInfo.selection]["id_to_name"][id_float_value]
-    if not matte_name then
-        return
-    end
-
-    -- create an updated version of the matte list string
-    local new_matte_list = update_matte_list(cInfo, matte_name, false, false, matte_selection)
-    if new_matte_list ~= nil then
-        TextMatteList:SetSource(Text(new_matte_list), 0, 0)
-    end
-end
-
-function remove_matte(cInfo, id_float_value, matte_selection)
-    --[[
-    Removes the matte with given id from the matte selection.
-
-    :param cInfo: cryptomatte info object
-    :type cInfo: CryptomatteInfo
-
-    :param id_float_value: id float value of the matte to remove
-    :type id_float_value: CryptomatteInfo
-
-    :param matte_selection: current matte selection string to update
-    :type matte_selection: string
-    ]]
-    -- get matte name of id float value
-    local matte_name = cInfo.cryptomattes[cInfo.selection]["id_to_name"][id_float_value]
-    if not matte_name then
-        return
-    end
-
-    -- create an updated version of the matte list string
-    local new_matte_list = update_matte_list(cInfo, matte_name, true, false, matte_selection)
-    if new_matte_list ~= nil then
-        TextMatteList:SetSource(Text(new_matte_list), 0, 0)
-    end
-end
-
-function set_name_checker(cInfo, layer_images, input_image)
-    --[[
-    Sets the name checker value of object at current locator position.
-
-    :param cInfo: cryptomatte info object
-    :type cInfo: CryptomatteInfo
-
-    :param layer_images: cryptomatte layer images by layer index as string
-                         Example: layer_images["1"] = (Image)CrytpoAsset01(RGBA)
-    :type layer_images: table[string, Image]
-
-    :param input_image: input image the locator position is relative to
-    :type input_image: Image
-    ]]
-    -- activates the name checker if the locator control is visible
-    local text_to_set = ""
-
-    -- only run code when locator is visible
-    local locator_visible = LocatorNameChecker:GetAttr("PC_Visible")
-    if locator_visible then
-        -- get screen pixel at locator position
-        local screen_pos = LocatorNameChecker:GetSource(0)
-        local id_float_value = cryptoutils:get_id_float_value(cInfo, screen_pos, layer_images, input_image)
-
-        -- get matte name matching id float value
-        if id_float_value == nil then
-            -- picking out of bounds
-            text_to_set = ""
-        elseif id_float_value == 0.0 then
-            -- no match
-            text_to_set = "Background (Value is 0.0)"
-        else
-            text_to_set = cInfo.cryptomattes[cInfo.selection]["id_to_name"][id_float_value]
-            if not text_to_set then
-                return
-            end
-            text_to_set = "\"" .. text_to_set .. "\""
-        end
-    end
-
-    -- set the keyed name if different then before
-    local keyed_name = TextKeyedName:GetSource(0).Value
-    if text_to_set ~= keyed_name then
-        TextKeyedName:SetSource(Text(text_to_set), 0, 0)
-    end
-end
-
-function get_view_mode()
-    --[[
-    Gets the current view mode.
-
-    If the "Keyable Surface" is checked, the set view mode will be returned.
-    If the "Keyable Surface" is unchecked, view mode "None" will be returned.
-
-    :rtype: string
-    ]]
-    -- returns the selected view mode if the preview checbkbox is checked
-    -- else return default view mode "None"
-    if CbPreview:GetSource(0).Value == 1  then
-        return VIEW_MODES[ComboViewMode:GetSource(0).Value + 1]
-    end
-    return VIEW_MODE_NONE
-end
-
-function apply_view_mode(view_mode, input_image, layer_images)
-    --[[
-    Builds an image based on the given view mode.
-
-    :param view_mode: view mode to build image for
-    :type view_mode: string
-
-    :param input_image: input image used to build view mode image
-    :type input_image: Image
-
-    :param layer_images: cryptomatte layer images by layer index as string
-                         Example: layer_images["1"] = (Image)CrytpoAsset01(RGBA)
-    :type layer_images: table[string, Image]
-
-    :return: image based on given view mode
-    :rtype: Image
-    ]]
-    local result
-    if view_mode == VIEW_MODE_EDGES then
-        -- edge mode
-        -- output.R += layer["0"].A * 2
-        -- output.G += layer["0"].A * 2
-        local coverage = layer_images["0"]:CopyOf()
-        coverage:Gain(1.0, 1.0, 1.0, 2.0)
-        result = input_image:ChannelOpOf("Add", coverage, {G="fg.A", B="fg.A"})
-    elseif view_mode == VIEW_MODE_COLORS then
-        -- colors mode generates an "ID" colored image based on an algorithm
-        -- using the first two layers
-        result = cryptoutils:create_preview_image(layer_images["0"],
-                                                  layer_images["1"],
-                                                  input_image)
-    elseif view_mode == VIEW_MODE_NONE then
-        -- pass input copy as output
-        result = input_image:CopyOf()
-    else
-        error(string.format("ERROR: unknown view mode "..view_mode))
-    end
-    return result
-end
-
--- =============================================================================
--- main
--- =============================================================================
 function Process(req)
     --[[
     Processes all events for one render cycle.
@@ -572,128 +262,207 @@ function Process(req)
     :param req: render request object
     :type req: Request
     ]]
+    local t_start = os.clock()
+    cryptoutils.log_info("-- process started")
+
+    -- read current settings
+    local current_layer_count = SliderCryptoLayer:GetAttr("INP_MaxAllowed")
+    local current_layer_index = SliderCryptoLayer:GetSource(0).Value
+    local current_layer_name = TextCryptoLayer:GetSource(0).Value
+    local current_matte_names_str = TextMatteList:GetSource(0).Value
+
     -- get input image
     local input_image = InImage:GetValue(req)
-    local metadata = input_image.Metadata
 
-    -- get current selected layer
-    local layer_name = get_selected_layer()
+    -- read metadata
+    cryptoutils.log_info("reading metadata ...")
+    local metadata = cryptoutils.get_cryptomatte_metadata(input_image.Metadata)
 
-    -- create cryptomatte information object
-    local cInfo = cryptoutils:create_cryptomatte_info(metadata, layer_name)
+    -- detect GUI changes
+    local layer_count = metadata["layer_count"]
+    local layer_index = current_layer_index
+    if layer_index > layer_count then
+        layer_index = 1
+    end
+    local layer_id = metadata["index_to_id"][current_layer_index]
+    local layer_name = metadata["id_to_name"][layer_id]
 
-    -- set layer slider values
-    set_layer_selection_slider(cInfo, layer_name)
+    -- apply GUI updates
+    if layer_count ~= current_layer_count then
+        SliderCryptoLayer:SetAttrs({INP_MinAllowed = 1,
+                                    INP_MaxAllowed = layer_count,
+                                    INP_MinScale = 1,
+                                    INP_MaxScale = layer_count})
+    end
 
-    -- display layer name
-    set_layer_selection_display(cInfo)
+    if layer_index ~= current_layer_index then
+        cryptoutils.log_info(string.format("setting layer index: %s", layer_index))
+        SliderCryptoLayer:SetSource(Number(layer_index), 0, 0)
+    end
 
-    -- get EXR layer images
-    local layer_images = cryptoutils:get_exr_layer_images(cInfo, layer_name, input_image)
+    if layer_name ~= current_layer_name then
+        cryptoutils.log_info(string.format("setting layer name: %s", layer_name))
+        TextCryptoLayer:SetSource(Text(layer_name), 0, 0)
+    end
 
-    -- set the name checker
-    set_name_checker(cInfo, layer_images, input_image)
+    -- read raw manifest from file
+    local manifest_file = metadata["layers"][layer_id]["manif_file"]
+    local raw_manifest = metadata["layers"][layer_id]["manifest"]
+    if manifest_file ~= nil then
+        cryptoutils.log_info(string.format("reading manifest file: %s", manifest_file))
+        raw_manifest = cryptoutils.read_manifest_file(metadata["path"], manifest_file)
+    end
 
-    -- add matte callback
-    -- remove matte callback
-    -- toggle matte callback
-    local add_triggered = CallbackBtnAdd:GetValue(req).Value
-    local remove_triggered = CallbackBtnRemove:GetValue(req).Value
-    local toggle_triggered = CallbackBtnToggle:GetValue(req).Value
-    local matte_selection = get_matte_selection_string()
-    if add_triggered == 1 or remove_triggered == 1 or toggle_triggered == 1 then
-        -- get the id float value from the pixel at locator coordinates
-        local screen_pos = Locator:GetSource(0)
-        local id_float_value = cryptoutils:get_id_float_value(cInfo, screen_pos, layer_images, input_image)
+    -- decode manifest string to table
+    cryptoutils.log_info("decoding manifest ...")
+    local manifest = cryptoutils.decode_manifest(raw_manifest)
 
-        if toggle_triggered == 1 then
-            if id_float_value ~= nil then
-                toggle_matte(cInfo, id_float_value, matte_selection)
+    -- create layer images
+    cryptoutils.log_info("creating layer images ...")
+    local layer_images = cryptoutils.get_layer_images(input_image, metadata["path"], layer_name, 1)
+
+    -- get matte names
+    cryptoutils.log_info("reading matte names ...")
+    local matte_names = cryptoutils.get_matte_names(current_matte_names_str)
+    local matte_name_str = current_matte_names_str
+
+    -- apply callbacks
+    local callback_add = CheckboxAdd:GetSource(0).Value
+    local callback_remove = CheckboxRemove:GetSource(0).Value
+    local callback_toggle = CheckboxToggle:GetSource(0).Value
+
+    if callback_add == 1 or callback_remove == 1 or callback_toggle == 1 then
+        cryptoutils.log_info("processing callbacks ...")
+        local screen_pos = LocatorMatte:GetSource(0)
+        local matte_name = module.get_screen_matte_name(input_image, layer_images, screen_pos, manifest)
+        local update = false
+
+        if callback_add == 1 then
+            if matte_name ~= nil then
+                if matte_names[matte_name] == nil then
+                    cryptoutils.log_info(string.format("adding matte: %s", matte_name))
+                    matte_names[matte_name] = true
+                    update = true
+                end
             end
-            -- reset the callback
-            CallbackBtnToggle:SetSource(Number(0), 0, 0)
+            CheckboxAdd:SetSource(Number(0), 0, 0)
         end
-        if add_triggered == 1 then
-            if id_float_value ~= nil then
-                add_matte(cInfo, id_float_value, matte_selection)
+        if callback_remove == 1 then
+            if matte_name ~= nil then
+                if matte_names[matte_name] then
+                    cryptoutils.log_info(string.format("removing matte: %s", matte_name))
+                    matte_names[matte_name] = nil
+                    update = true
+                end
             end
-            -- reset the callback
-            CallbackBtnAdd:SetSource(Number(0), 0, 0)
+            CheckboxRemove:SetSource(Number(0), 0, 0)
         end
-        if remove_triggered == 1 then
-            if id_float_value ~= nil then
-                remove_matte(cInfo, id_float_value, matte_selection)
+        if callback_toggle == 1 then
+            if matte_name ~= nil then
+                if matte_names[matte_name] then
+                    cryptoutils.log_info(string.format("removing matte: %s", matte_name))
+                    matte_names[matte_name] = nil
+                    update = true
+                else
+                    cryptoutils.log_info(string.format("adding matte: %s", matte_name))
+                    matte_names[matte_name] = true
+                    update = true
+                end
             end
-            -- reset the callback
-            CallbackBtnRemove:SetSource(Number(0), 0, 0)
+            CheckboxToggle:SetSource(Number(0), 0, 0)
+        end
+
+        if update then
+            name_array = {}
+            for name, presence in pairs(matte_names) do
+                if presence then
+                    table.insert(name_array, "\"" .. name .. "\"")
+                end
+            end
+            matte_name_str = table.concat(name_array, ", ")
+            TextMatteList:SetSource(Text(matte_name_str), 0, 0)
         end
     end
 
-    -- create output image depending on view mode
-    local view_mode = get_view_mode()
-    local output_image = apply_view_mode(view_mode, input_image, layer_images)
-
-    -- create matte
-    local matte_names = cryptoutils:get_matte_names_from_selection(cInfo, matte_selection)
-    local matte = cryptoutils:create_matte_image(cInfo, matte_names, layer_images, output_image)
-
-    -- apply matte to output image
-    if matte ~= nil then
-        output_image = output_image:ChannelOpOf("Add", matte, { R = "fg.A", G = "fg.A"})
-        output_image = output_image:ChannelOpOf("Copy", matte, { A = "fg.A"})
+    -- set name checker
+    local checker_locator_visible = LocatorName:GetAttr("PC_Visible")
+    if checker_locator_visible then
+        cryptoutils.log_info("updating name checker ...")
+        local checker_screen_pos = LocatorName:GetSource(0)
+        local checker_matte_name = module.get_screen_matte_name(input_image, layer_images, checker_screen_pos, manifest)
+        local current_matte_name = TextMatteName:GetSource(0).Value
+        if checker_matte_name ~= current_matte_name then
+            TextMatteName:SetSource(Text(checker_matte_name), 0, 0)
+        end
     end
 
-    -- matte only callback
-    local matte_only = CbMatteOnly:GetValue(req).Value
+    -- create matte image
+    cryptoutils.log_info("creating matte image ...")
+    local matte_image = cryptoutils.create_matte_image(input_image, layer_images, manifest, matte_names)
+
+    -- set output image
+    local matte_only = CheckboxMatteOnly:GetSource(0).Value
     if matte_only == 1 then
-        -- enable preview feature
-        CbPreview:SetAttrs({ INP_Disabled = true })
-        ComboViewMode:SetAttrs({ INP_Disabled = true })
-
-        -- output mono channel alpha image
-        OutImage:Set(req, matte)
+        OutImage:Set(req, matte_image)
     else
-        -- disable preview feature
-        CbPreview:SetAttrs({ INP_Disabled = false })
-        ComboViewMode:SetAttrs({ INP_Disabled = false })
+        -- get view mode
+        local view_mode_enabled = CheckboxViewMode:GetSource(0).Value
+        local view_mode = VIEW_MODE_NONE
+        if view_mode_enabled == 1 then
+            local view_mode_index = ComboViewMode:GetSource(0).Value
+            view_mode = VIEW_MODES[view_mode_index + 1]
+        end
 
-        -- output preview mode with matte applied
-        OutImage:Set(req, output_image)
+        -- create preview image
+        cryptoutils.log_info(string.format("creating '%s' preview image ...", view_mode))
+        local preview_image
+        if view_mode == VIEW_MODE_EDGES then
+            preview_image = cryptoutils.create_preview_image_edges(input_image, layer_images)
+        elseif view_mode == VIEW_MODE_COLORS then
+            preview_image = cryptoutils.create_preview_image_colors(input_image, layer_images)
+        elseif view_mode == VIEW_MODE_NONE then
+            preview_image = input_image:CopyOf()
+        end
+
+        -- apply matte image
+        preview_image = preview_image:ChannelOpOf("Add", matte_image, { R = "fg.A", G = "fg.A"})
+        preview_image = preview_image:ChannelOpOf("Copy", matte_image, { A = "fg.A"})
+        OutImage:Set(req, preview_image)
     end
+
+    local t_end = os.clock() - t_start
+    cryptoutils.log_info(string.format("elapsed time: %.3f", t_end))
+    cryptoutils.log_info("-- process ended")
 end
 
 function NotifyChanged(inp, param, time)
     --[[
     Handles all input control events.
 
-    :param inp: input that triggered a signal
+    :param inp: Input that triggered a signal.
     :type inp: Input
 
-    :param param: parameter object holding the (new) value
+    :param param: Parameter object holding the (new) value.
     :type param: Parameter
 
-    :param time: current frame number
+    :param time: Current frame number.
     :type time: float
     ]]
     -- trigger callbacks
     if param and param.Value == 1 then
-        if inp == BtnAdd then
-            CallbackBtnAdd:SetSource(Number(1), 0, 0)
-        elseif inp == BtnRemove then
-            CallbackBtnRemove:SetSource(Number(1), 0, 0)
-        elseif inp == BtnToggle then
-            CallbackBtnToggle:SetSource(Number(1), 0, 0)
-        elseif inp == BtnClear then
-            -- clear matte list input
+        if inp == ButtonAdd then
+            CheckboxAdd:SetSource(Number(1), 0, 0)
+        elseif inp == ButtonRemove then
+            CheckboxRemove:SetSource(Number(1), 0, 0)
+        elseif inp == ButtonToggle then
+            CheckboxToggle:SetSource(Number(1), 0, 0)
+        elseif inp == ButtonClear then
             TextMatteList:SetSource(Text(""), 0, 0)
-            -- uncheck matte only
-            CbMatteOnly:SetSource(Number(0), 0, 0)
-            -- uncheck preview
-            CbPreview:SetSource(Number(0), 0, 0)
-        elseif inp == BtnShow then
-            LocatorNameChecker:SetAttrs({ PC_Visible = true })
-        elseif inp == BtnHide then
-            LocatorNameChecker:SetAttrs({ PC_Visible = false })
+        elseif inp == ButtonShow then
+            LocatorName:SetAttrs({PC_Visible = true})
+        elseif inp == ButtonHide then
+            TextMatteName:SetSource(Text(""), 0, 0)
+            LocatorName:SetAttrs({PC_Visible = false})
         end
     end
 end

--- a/fusion/Fuses/Matte/cryptomatte.fuse
+++ b/fusion/Fuses/Matte/cryptomatte.fuse
@@ -27,7 +27,7 @@ VIEW_MODE_EDGES = "Edges"
 VIEW_MODE_COLORS = "Colors"
 VIEW_MODE_NONE = "None"
 VIEW_MODES = {VIEW_MODE_EDGES, VIEW_MODE_COLORS, VIEW_MODE_NONE}
-SHOW_CALLBACKS = true
+SHOW_CALLBACKS = false
 
 
 -- ============================================================================

--- a/fusion/Modules/Lua/cryptomatte_utilities.lua
+++ b/fusion/Modules/Lua/cryptomatte_utilities.lua
@@ -367,7 +367,7 @@ function module._get_log_level()
     ]]
     local log_level = os.getenv(ENV_VAR_LOG_LEVEL)
     if log_level == nil then
-        return 0
+        return 1
     end
     return tonumber(log_level)
 end

--- a/fusion/Modules/Lua/cryptomatte_utilities.lua
+++ b/fusion/Modules/Lua/cryptomatte_utilities.lua
@@ -34,6 +34,7 @@ end
 
 -- load cjson module if present, if not, load Fusion stdlib dkjson module
 local json = prefered_load("cjson", "dkjson")
+local bit = require("bit")
 
 -- ============================================================================
 -- constants
@@ -536,6 +537,12 @@ function module._hex_to_float(hex)
     :rtype: number
     ]]
     int_flt.i = tonumber(hex, 16)
+    --fix exponent if required
+    local exp = bit.rshift(int_flt.i, 23)
+    exp = bit.band(exp, 255)
+    if exp == 0 or exp == 255 then
+        int_flt.i = bit.bxor(int_flt.i, bit.lshift(1, 23))
+    end
     return int_flt.f
 end
 

--- a/fusion/Modules/Lua/cryptomatte_utilities.lua
+++ b/fusion/Modules/Lua/cryptomatte_utilities.lua
@@ -336,17 +336,19 @@ end
 module = {}
 
 -- private
-function module._log(level, msg)
+function module._format_log(level, message)
     --[[
-    Logs a message.
+    Returns a formatted message to log.
 
     :param level: Name of the log level.
     :type level: string
 
-    :param msg: Message to log.
-    :type msg: string
+    :param message: Message to log.
+    :type message: string
+
+    :rtype: string
     ]]
-    print(string.format("[Cryptomatte][%s] %s", level, msg))
+    return string.format("[Cryptomatte][%s][%s] %s", self.Name, level, message)
 end
 
 function module._get_log_level()
@@ -365,7 +367,7 @@ function module._get_log_level()
     ]]
     local log_level = os.getenv(ENV_VAR_LOG_LEVEL)
     if log_level == nil then
-        return 1
+        return 0
     end
     return tonumber(log_level)
 end
@@ -538,40 +540,43 @@ function module._hex_to_float(hex)
 end
 
 -- public
-function module.log_error(msg)
+function module.log_error(message)
     --[[
     Logs an error message.
 
-    :param msg: Message to log.
+    :param message: Message to log.
+    :type message: string
     ]]
     local log_level = module._get_log_level()
     if log_level >= 0 then
-        module._log("ERROR", msg)
+        print(module._format_log("ERROR", message))
     end
     error("ERROR")
 end
 
-function module.log_warning(msg)
+function module.log_warning(message)
     --[[
-    Logs an error message.
+    Logs an warning message.
 
-    :param msg: Message to log.
+    :param message: Message to log.
+    :type message: string
     ]]
     local log_level = module._get_log_level()
     if log_level >= 1 then
-        module._log("WARNING", msg)
+        print(module._format_log("WARNING", message))
     end
 end
 
-function module.log_info(msg)
+function module.log_info(message)
     --[[
     Logs an information message.
 
-    :param msg: Message to log.
+    :param message: Message to log.
+    :type message: string
     ]]
     local log_level = module._get_log_level()
-    if log_level > 2 then
-        module._log("INFO", msg)
+    if log_level >= 2 then
+        print(module._format_log("INFO", message))
     end
 end
 

--- a/fusion/Modules/Lua/cryptomatte_utilities.lua
+++ b/fusion/Modules/Lua/cryptomatte_utilities.lua
@@ -189,7 +189,7 @@ function create_preview_image_colors_scanline(n)
     pixptr_01:GotoXY(output_image.DataWindow.left, y)
     pixptr_out:GotoXY(output_image.DataWindow.left, y)
 
-    for x = output_image.DataWindow.left, output_image.DataWindow.right - 1 do
+    for _ = output_image.DataWindow.left, output_image.DataWindow.right - 1 do
         -- go to correct X position
         pixptr_00:GetNextPixel(global_p_00)
         pixptr_01:GetNextPixel(global_p_01)
@@ -284,8 +284,8 @@ function create_matte_image_scanline(n)
     pixptr_in:GotoXY(dod.left, y)
     pixptr_out:GotoXY(dod.left, y)
 
-    local update = false
-    for x = dod.left, dod.right - 1 do
+    local update
+    for _ = dod.left, dod.right - 1 do
         -- go to correct X position
         pixptr_in:GetNextPixel(input_p)
         pixptr_out:GetPixel(output_p)
@@ -439,16 +439,16 @@ function module._get_channel_hierarchy(layer_name, channels)
     :type layer_name: string
 
     :param channels: All channel objects of an EXR file.
-    :type channels: table[number, table]
+    :type channels: table[table]
 
     :rtype: table
     ]]
     local hierarchy = {}
-    for i, channel in ipairs(channels) do
+    for _, channel in ipairs(channels) do
         full_channel_name = channel["Name"]
         if module._string_starts_with(full_channel_name, layer_name) then
             -- get layer name & index info from channel name
-            local _layer_name, layer_index, channel_name = string.match(full_channel_name, REGEX_LAYER_CHANNEL)
+            local _, layer_index, channel_name = string.match(full_channel_name, REGEX_LAYER_CHANNEL)
 
             -- get internal channel name representation
             local internal_channel_name = nil
@@ -635,7 +635,6 @@ function module.read_manifest_file(exr_path, sidecar_file_path)
     ]]
     -- build absolute sidecar file path
     local path = exr_path:match("(.*/)") .. sidecar_file_path
-
     local fp = io.open(path, "r")
     if fp == nil then
         module.log_error(string.format("unable to open manifest file: %s", path))
@@ -878,7 +877,7 @@ function module.get_screen_matte_name(input_image, layer_images, screen_pos, man
     matte_names_by_value[0.0] = BACKGROUND_MATTE_NAME
 
     local matte_value = nil
-    for layer_index, layer_image in pairs(layer_images) do
+    for _, layer_image in pairs(layer_images) do
         -- get pixel at screen coordinates for current layer image
         local pixel = get_screen_pixel(layer_image, x, y)
 

--- a/fusion/Modules/Lua/test_cryptomatte_utilities.lua
+++ b/fusion/Modules/Lua/test_cryptomatte_utilities.lua
@@ -202,6 +202,10 @@ function module.test_log_error()
     -- TODO
 end
 
+function module.test_log_warning()
+    -- TODO
+end
+
 function module.test_log_info()
     -- TODO
 end

--- a/fusion/Modules/Lua/test_cryptomatte_utilities.lua
+++ b/fusion/Modules/Lua/test_cryptomatte_utilities.lua
@@ -79,8 +79,9 @@ end
 
 -- mock funtions
 storage = {}
-function mock_print(msg)
-    storage["print_return"] = msg
+
+function mock_print(message)
+    storage["print_return"] = message
 end
 
 function mock_log_level_unset()
@@ -99,7 +100,7 @@ function mock_log_level_info()
     return "2"
 end
 
-function mock_node()
+function mock_self_node()
     return {Name="NODE1"}
 end
 
@@ -107,11 +108,10 @@ end
 module = {}
 
 function module.test__format_log()
-    old_self = self
-    self = mock_node()
-    local result = cryptoutils._format_log("LEVEL", "MESSAGE")
+    local old_self = self
+    self = mock_self_node()
+    assert_equal(cryptoutils._format_log("LEVEL", "MESSAGE"), "[Cryptomatte][NODE1][LEVEL] MESSAGE")
     self = old_self
-    assert_equal(result, "[Cryptomatte][NODE1][LEVEL] MESSAGE")
 end
 
 function module.test__get_log_level()

--- a/fusion/Modules/Lua/test_cryptomatte_utilities.lua
+++ b/fusion/Modules/Lua/test_cryptomatte_utilities.lua
@@ -229,19 +229,28 @@ function cryptomatte_test_log_warning()
     old_self = self
     old_print = _G["print"]
 
-    -- mock
+    -- mock with matching log level
     _G["os"]['getenv'] = mock_log_level_warning
     self = mock_self_node()
     _G["print"] = mock_print
 
     cryptoutils.log_warning("HELP")
+    local pr1 = storage["print_return"]
+    storage["print_return"] = nil  -- clear print result for next run
+
+    -- mock with non matching log level
+    _G["os"]['getenv'] = mock_log_level_unset
+
+    cryptoutils.log_warning("HELP")
+    local pr2 = storage["print_return"]
 
     -- reset mock
     _G["os"]["getenv"] = old_get_env
     self = old_self
     _G["print"] = old_print
 
-    assert_equal(storage["print_return"], "[Cryptomatte][NODE1][WARNING] HELP")
+    assert_equal(pr1, "[Cryptomatte][NODE1][WARNING] HELP")
+    assert_equal(pr2, nil)  -- never got called
 end
 
 function cryptomatte_test_log_info()
@@ -256,13 +265,22 @@ function cryptomatte_test_log_info()
     _G["print"] = mock_print
 
     cryptoutils.log_info("HELP")
+    local pr1 = storage["print_return"]
+    storage["print_return"] = nil  -- clear print result for next run
+
+    -- mock with non matching log level
+    _G["os"]['getenv'] = mock_log_level_unset
+
+    cryptoutils.log_info("HELP")
+    local pr2 = storage["print_return"]
 
     -- reset mock
     _G["os"]["getenv"] = old_get_env
     self = old_self
     _G["print"] = old_print
 
-    assert_equal(storage["print_return"], "[Cryptomatte][NODE1][INFO] HELP")
+    assert_equal(pr1, "[Cryptomatte][NODE1][INFO] HELP")
+    assert_equal(pr2, nil)  -- never got called
 end
 
 function cryptomatte_test_get_cryptomatte_metadata()

--- a/fusion/Modules/Lua/test_cryptomatte_utilities.lua
+++ b/fusion/Modules/Lua/test_cryptomatte_utilities.lua
@@ -79,7 +79,7 @@ function assert_equal(x, y)
     if _x == _y then
         return true
     else
-        error(string.format("%s\nassertion failed: %s != %s", debug.traceback(), x, y))
+        error(string.format("%s\nassertion failed: %s != %s", debug.traceback(), _x, _y))
     end
 end
 
@@ -343,6 +343,12 @@ function cryptomatte_test_get_matte_names()
     expected["b u n n y"] = true
     assert_equal(result, expected)
 
+    -- valid name string with special characters
+    result = cryptoutils.get_matte_names("\"bunny?!\"")
+    expected = {}
+    expected["bunny?!"] = true
+    assert_equal(result, expected)
+
     -- valid name string with latin encoding characters
     result = cryptoutils.get_matte_names("\"itsabunnyé\"")
     expected = {}
@@ -365,12 +371,14 @@ function cryptomatte_test_get_matte_names()
     _G["print"] = mock_print
 
     local no_quotes = cryptoutils.get_matte_names("bunny")
+    local comma = cryptoutils.get_matte_names("bu,nny")
 
     -- reset mock
     self = old_self
     _G["print"] = old_print
 
     assert_equal(no_quotes, {})
+    assert_equal(comma, {})
 end
 
 run_tests()

--- a/fusion/Modules/Lua/test_cryptomatte_utilities.lua
+++ b/fusion/Modules/Lua/test_cryptomatte_utilities.lua
@@ -43,16 +43,29 @@ function run_tests()
     local ntests = #tests
     print(string.format("detected %s test(s) ...", ntests))
 
+    print("running tests ...")
     local count = 0
     for _, name in ipairs(tests) do
         count = count + 1
+
+        -- build progess percentage
         local percentage = (count / ntests) * 100
         local percentage_str = string.format("%.0f%%", percentage)
         local padding = string.rep(" ", 4 - string.len(percentage_str))
         percentage_str = string.format("%s%s", padding, percentage_str)
+
+        -- build test report
         local report = string.format("[%s] %s ... ", percentage_str, name)
 
+        -- add leading spaces to allign results
+        while report:len() < 60 do
+            report = report.." "
+        end
+
+        -- safe call test function
         local status, err = pcall(_G[name])
+
+        -- error handling & final report update
         if status then
             report = string.format("%s [%s]", report, "OK")
         else

--- a/fusion/Modules/Lua/test_cryptomatte_utilities.lua
+++ b/fusion/Modules/Lua/test_cryptomatte_utilities.lua
@@ -310,7 +310,33 @@ function cryptomatte_test_log_info()
 end
 
 function cryptomatte_test_get_cryptomatte_metadata()
-    -- TODO
+    local metadata = {}
+    metadata["cryptomatte/123456/conversion"] = "uint32_to_float32"
+    metadata["cryptomatte/123456/hash"] = "MurmurHash3_32"
+    metadata["cryptomatte/123456/manifest"] = "{\"bunny\": \"3f800000\"}"
+    metadata["cryptomatte/123456/name"] = "Layer"
+    metadata["Filename"] = "/tmp/foo"
+
+    local result = cryptoutils.get_cryptomatte_metadata(metadata)
+    local expected = {}
+    expected["path"] = "/tmp/foo"
+    expected["layer_count"] = 1
+    expected["id_to_name"] = {}
+    expected["id_to_name"]["123456"]="Layer"
+    expected["name_to_id"] = {}
+    expected["name_to_id"]["Layer"] = "123456"
+    expected["index_to_id"] = {}
+    expected["index_to_id"]["123456"] = 1
+    expected["id_to_index"] = {}
+    expected["id_to_index"]["1"] = "123456"
+    expected["layers"] = {}
+    expected["layers"]["123456"] = {}
+    expected["layers"]["123456"]["conversion"] = "uint32_to_float32"
+    expected["layers"]["123456"]["hash"] = "MurmurHash3_32"
+    expected["layers"]["123456"]["manifest"] = "{\"bunny\": \"3f800000\"}"
+    expected["layers"]["123456"]["name"] = "Layer"
+
+    assert_equal(result, expected)
 end
 
 function cryptomatte_test_read_manifest_file()

--- a/fusion/Modules/Lua/test_cryptomatte_utilities.lua
+++ b/fusion/Modules/Lua/test_cryptomatte_utilities.lua
@@ -10,20 +10,17 @@ Version    : 1.2.8
 local cryptoutils = require("cryptomatte_utilities")
 
 -- utils
-function collect_tests(module)
+function collect_tests()
     --[[
     Returns function names detected as test.
 
     Functions with names starting with "test_" will be picked up.
 
-    :param module: Module to collect test function names of.
-    :type module: table[string, function]
-
     :rtype: table[stri]
     ]]
     local tests = {}
-    local substr = "test_"
-    for name, _ in pairs(module) do
+    local substr = "cryptomatte_test_"
+    for name, _ in pairs(_G) do
         if string.sub(name, 1, string.len(substr)) == substr then
             table.insert(tests, name)
         end
@@ -32,7 +29,7 @@ function collect_tests(module)
     return tests
 end
 
-function run_tests(module)
+function run_tests()
     --[[
     Detects and runs all test functions of a module.
 
@@ -41,7 +38,7 @@ function run_tests(module)
     ]]
     -- collect all tests from module
     print("collectings test(s) ...")
-    local tests = collect_tests(module)
+    local tests = collect_tests()
     local ntests = #tests
     print(string.format("detected %s test(s) ...", ntests))
 
@@ -54,7 +51,7 @@ function run_tests(module)
         percentage_str = string.format("%s%s", padding, percentage_str)
         local report = string.format("[%s] %s ... ", percentage_str, name)
 
-        local status, err = pcall(module[name])
+        local status, err = pcall(_G[name])
         if status then
             report = string.format("%s [%s]", report, "OK")
         else
@@ -79,6 +76,10 @@ end
 
 -- mock funtions
 storage = {}
+
+function mock_error(message)
+    storage["error_return"] = message
+end
 
 function mock_print(message)
     storage["print_return"] = message
@@ -105,42 +106,41 @@ function mock_self_node()
 end
 
 -- tests
-module = {}
-
-function module.test__format_log()
+function cryptomatte_test__format_log()
     local old_self = self
     self = mock_self_node()
     assert_equal(cryptoutils._format_log("LEVEL", "MESSAGE"), "[Cryptomatte][NODE1][LEVEL] MESSAGE")
     self = old_self
 end
 
-function module.test__get_log_level()
-    old_get_env = os.getenv
+function cryptomatte_test__get_log_level()
+    -- store original function pre mock
+    old_get_env = _G["os"]["getenv"]
 
     -- mock log level not set in environment
-    os.getenv = mock_log_level_unset
+    _G["os"]["getenv"] = mock_log_level_unset
     local r1 = cryptoutils._get_log_level()
-    os.getenv = old_get_env
+    _G["os"]["getenv"] = old_get_env
     assert_equal(r1, 0)
 
     -- mock log level info set in environment (string -> number cast)
-    os.getenv = mock_log_level_info
+    _G["os"]["getenv"] = mock_log_level_info
     local r2 = cryptoutils._get_log_level()
-    os.getenv = old_get_env
+    _G["os"]["getenv"] = old_get_env
     assert_equal(r2, 2)
 end
 
-function module.test__string_starts_with()
+function cryptomatte_test__string_starts_with()
     assert_equal(cryptoutils._string_starts_with("foo_bar", "foo_"), true)
     assert_equal(cryptoutils._string_starts_with("foo_bar", "bar"), false)
 end
 
-function module.test__string_ends_with()
+function cryptomatte_test__string_ends_with()
     assert_equal(cryptoutils._string_ends_with("foo_bar", "_bar"), true)
     assert_equal(cryptoutils._string_ends_with("foo_bar", "foo"), false)
 end
 
-function module.test__string_split()
+function cryptomatte_test__string_split()
     result = cryptoutils._string_split("foo, bar,bunny", "([^,]+),?%s*")
     assert_equal(#result, 3)
     expected = {"foo", "bar", "bunny"}
@@ -149,7 +149,7 @@ function module.test__string_split()
     end
 end
 
-function module.test__solve_channel_name()
+function cryptomatte_test__solve_channel_name()
     -- r
     assert_equal(cryptoutils._solve_channel_name("r"), "r")
     assert_equal(cryptoutils._solve_channel_name("R"), "r")
@@ -175,17 +175,17 @@ function module.test__solve_channel_name()
     assert_equal(cryptoutils._solve_channel_name("ALPHA"), "a")
 end
 
-function module.test__get_channel_hierarchy()
+function cryptomatte_test__get_channel_hierarchy()
     -- TODO
 end
 
-function module.test__get_absolute_position()
+function cryptomatte_test__get_absolute_position()
     local x, y = cryptoutils._get_absolute_position(10, 10, 0.5, 0.5)
     assert_equal(x, 5)
     assert_equal(y, 5)
 end
 
-function module.test__is_position_in_rect()
+function cryptomatte_test__is_position_in_rect()
     -- NOTE: fusion rectangles follow mathematical convention, (origin=left,bottom)
     local rect = {left=0, top=10, right=10, bottom=0}
     assert_equal(cryptoutils._is_position_in_rect(rect, 5, 5), true)
@@ -193,37 +193,92 @@ function module.test__is_position_in_rect()
     assert_equal(cryptoutils._is_position_in_rect(rect, 5, 12), false)
 end
 
-function module.test__hex_to_float()
+function cryptomatte_test__hex_to_float()
     assert_equal(cryptoutils._hex_to_float("3f800000"), 1.0)
     assert_equal(cryptoutils._hex_to_float("bf800000"), -1.0)
 end
 
-function module.test_log_error()
+function cryptomatte_test_log_error()
+    -- store original pre mock
+    old_get_env = _G["os"]["getenv"]
+    old_self = self
+    old_print = _G["print"]
+    old_error = _G["error"]
+
+    -- mock
+    _G["os"]['getenv'] = mock_log_level_error
+    self = mock_self_node()
+    _G["print"] = mock_print
+    _G["error"] = mock_error
+
+    cryptoutils.log_error("HELP")
+
+    -- reset mock
+    _G["os"]["getenv"] = old_get_env
+    self = old_self
+    _G["print"] = old_print
+    _G["error"] = old_error
+
+    assert_equal(storage["print_return"], "[Cryptomatte][NODE1][ERROR] HELP")
+    assert_equal(storage["error_return"], "ERROR")
+end
+
+function cryptomatte_test_log_warning()
+    -- store original pre mock
+    old_get_env = _G["os"]["getenv"]
+    old_self = self
+    old_print = _G["print"]
+
+    -- mock
+    _G["os"]['getenv'] = mock_log_level_warning
+    self = mock_self_node()
+    _G["print"] = mock_print
+
+    cryptoutils.log_warning("HELP")
+
+    -- reset mock
+    _G["os"]["getenv"] = old_get_env
+    self = old_self
+    _G["print"] = old_print
+
+    assert_equal(storage["print_return"], "[Cryptomatte][NODE1][WARNING] HELP")
+end
+
+function cryptomatte_test_log_info()
+    -- store original pre mock
+    old_get_env = _G["os"]["getenv"]
+    old_self = self
+    old_print = _G["print"]
+
+    -- mock
+    _G["os"]['getenv'] = mock_log_level_info
+    self = mock_self_node()
+    _G["print"] = mock_print
+
+    cryptoutils.log_info("HELP")
+
+    -- reset mock
+    _G["os"]["getenv"] = old_get_env
+    self = old_self
+    _G["print"] = old_print
+
+    assert_equal(storage["print_return"], "[Cryptomatte][NODE1][INFO] HELP")
+end
+
+function cryptomatte_test_get_cryptomatte_metadata()
     -- TODO
 end
 
-function module.test_log_warning()
+function cryptomatte_test_read_manifest_file()
     -- TODO
 end
 
-function module.test_log_info()
+function cryptomatte_test_decode_manifest()
     -- TODO
 end
 
-function module.test_get_cryptomatte_metadata()
+function cryptomatte_test_get_matte_names()
     -- TODO
 end
 
-function module.test_read_manifest_file()
-    -- TODO
-end
-
-function module.test_decode_manifest()
-    -- TODO
-end
-
-function module.test_get_matte_names()
-    -- TODO
-end
-
-run_tests(module)
+run_tests()

--- a/fusion/Modules/Lua/test_cryptomatte_utilities.lua
+++ b/fusion/Modules/Lua/test_cryptomatte_utilities.lua
@@ -1,0 +1,226 @@
+--[[
+Requires   : Fusion 9.0.2+
+Optional   : cjson
+Created by : Cédric Duriau         [duriau.cedric@live.be]
+             Kristof Indeherberge  [xmnr0x23@gmail.com]
+             Andrew Hazelden       [andrew@andrewhazelden.com]
+Version    : 1.2.8
+--]]
+
+local cryptoutils = require("cryptomatte_utilities")
+
+-- utils
+function collect_tests(module)
+    --[[
+    Returns function names detected as test.
+
+    Functions with names starting with "test_" will be picked up.
+
+    :param module: Module to collect test function names of.
+    :type module: table[string, function]
+
+    :rtype: table[stri]
+    ]]
+    local tests = {}
+    local substr = "test_"
+    for name, _ in pairs(module) do
+        if string.sub(name, 1, string.len(substr)) == substr then
+            table.insert(tests, name)
+        end
+    end
+    table.sort(tests)
+    return tests
+end
+
+function run_tests(module)
+    --[[
+    Detects and runs all test functions of a module.
+
+    :param module: Module to run all tests for.
+    :type module: table[string, function]
+    ]]
+    -- collect all tests from module
+    print("collectings test(s) ...")
+    local tests = collect_tests(module)
+    local ntests = #tests
+    print(string.format("detected %s test(s) ...", ntests))
+
+    local count = 0
+    for _, name in ipairs(tests) do
+        count = count + 1
+        local percentage = (count / ntests) * 100
+        local percentage_str = string.format("%.0f%%", percentage)
+        local padding = string.rep(" ", 4 - string.len(percentage_str))
+        percentage_str = string.format("%s%s", padding, percentage_str)
+        local report = string.format("[%s] %s ... ", percentage_str, name)
+
+        local status, err = pcall(module[name])
+        if status then
+            report = string.format("%s [%s]", report, "OK")
+        else
+            report = string.format("%s [%s]\n%s", report, "FAILED", err)
+        end
+        print(report)
+    end
+end
+
+function assert_equal(x, y)
+    --[[
+    Tests the equality of two variables.
+
+    :rtype: boolean
+    ]]
+    if x == y then
+        return true
+    else
+        error(string.format("%s\nassertion failed: %s != %s", debug.traceback(), x, y))
+    end
+end
+
+-- mock funtions
+storage = {}
+function mock_print(msg)
+    storage["print_return"] = msg
+end
+
+function mock_log_level_unset()
+    return nil
+end
+
+function mock_log_level_none()
+    return "0"
+end
+
+function mock_log_level_error()
+    return "1"
+end
+
+function mock_log_level_info()
+    return "2"
+end
+
+-- tests
+module = {}
+
+function module.test__log()
+    old_print = print
+    print = mock_print
+    cryptoutils._log("LEVEL", "MESSAGE")
+    print = old_print
+
+    assert_equal(storage["print_return"], "[Cryptomatte][LEVEL] MESSAGE")
+end
+
+function module.test__get_log_level()
+    old_get_env = os.getenv
+
+    -- mock log level not set in environment
+    os.getenv = mock_log_level_unset
+    local r1 = cryptoutils._get_log_level()
+    os.getenv = old_get_env
+    assert_equal(r1, 1)
+
+    -- mock log level set in environment (string -> number cast)
+    os.getenv = mock_log_level_info
+    local r2 = cryptoutils._get_log_level()
+    os.getenv = old_get_env
+    assert_equal(r2, 2)
+end
+
+function module.test__string_starts_with()
+    assert_equal(cryptoutils._string_starts_with("foo_bar", "foo_"), true)
+    assert_equal(cryptoutils._string_starts_with("foo_bar", "bar"), false)
+end
+
+function module.test__string_ends_with()
+    assert_equal(cryptoutils._string_ends_with("foo_bar", "_bar"), true)
+    assert_equal(cryptoutils._string_ends_with("foo_bar", "foo"), false)
+end
+
+function module.test__string_split()
+    result = cryptoutils._string_split("foo, bar,bunny", "([^,]+),?%s*")
+    assert_equal(#result, 3)
+    expected = {"foo", "bar", "bunny"}
+    for i, v in ipairs(result) do
+        assert_equal(v, expected[i])
+    end
+end
+
+function module.test__solve_channel_name()
+    -- r
+    assert_equal(cryptoutils._solve_channel_name("r"), "r")
+    assert_equal(cryptoutils._solve_channel_name("R"), "r")
+    assert_equal(cryptoutils._solve_channel_name("red"), "r")
+    assert_equal(cryptoutils._solve_channel_name("RED"), "r")
+
+    -- g
+    assert_equal(cryptoutils._solve_channel_name("g"), "g")
+    assert_equal(cryptoutils._solve_channel_name("G"), "g")
+    assert_equal(cryptoutils._solve_channel_name("green"), "g")
+    assert_equal(cryptoutils._solve_channel_name("GREEN"), "g")
+
+    -- b
+    assert_equal(cryptoutils._solve_channel_name("b"), "b")
+    assert_equal(cryptoutils._solve_channel_name("B"), "b")
+    assert_equal(cryptoutils._solve_channel_name("blue"), "b")
+    assert_equal(cryptoutils._solve_channel_name("BLUE"), "b")
+
+    -- a
+    assert_equal(cryptoutils._solve_channel_name("a"), "a")
+    assert_equal(cryptoutils._solve_channel_name("A"), "a")
+    assert_equal(cryptoutils._solve_channel_name("alpha"), "a")
+    assert_equal(cryptoutils._solve_channel_name("ALPHA"), "a")
+end
+
+function module.test__get_channel_hierarchy()
+    -- TODO
+end
+
+function module.test__get_absolute_position()
+    local x, y = cryptoutils._get_absolute_position(10, 10, 0.5, 0.5)
+    assert_equal(x, 5)
+    assert_equal(y, 5)
+end
+
+function module.test__is_position_in_rect()
+    -- NOTE: fusion rectangles follow mathematical convention, (origin=left,bottom)
+    local rect = {left=0, top=10, right=10, bottom=0}
+    assert_equal(cryptoutils._is_position_in_rect(rect, 5, 5), true)
+    assert_equal(cryptoutils._is_position_in_rect(rect, 12, 5), false)
+    assert_equal(cryptoutils._is_position_in_rect(rect, 5, 12), false)
+end
+
+function module.test__hex_to_float()
+    assert_equal(cryptoutils._hex_to_float("3f800000"), 1.0)
+    assert_equal(cryptoutils._hex_to_float("bf800000"), -1.0)
+end
+
+function module.test_log_error()
+    -- TODO
+end
+
+function module.test_log_info()
+    -- TODO
+end
+
+function module.test_get_cryptomatte_metadata()
+    -- TODO
+end
+
+function module.test_read_manifest_file()
+    -- TODO
+end
+
+function module.test_decode_manifest()
+    -- TODO
+end
+
+function module.test_get_matte_names()
+    -- TODO
+end
+
+function module.test_get_screen_matte_name()
+    -- TODO
+end
+
+run_tests(module)

--- a/fusion/Modules/Lua/test_cryptomatte_utilities.lua
+++ b/fusion/Modules/Lua/test_cryptomatte_utilities.lua
@@ -314,7 +314,36 @@ function cryptomatte_test_get_cryptomatte_metadata()
 end
 
 function cryptomatte_test_read_manifest_file()
-    -- TODO
+    -- valid manifest file
+    local tmp_file = os.tmpname()
+    local fp = io.open(tmp_file, "w")
+    fp:write("{\"bunny\": \"3f800000\"}")
+    fp:close()
+
+    local dir, file = string.match(tmp_file, "(.-)([^\\/]-%.?[^%.\\/]*)$")
+    local result = cryptoutils.read_manifest_file(dir, file)
+    os.remove(tmp_file)
+    assert_equal(result, "{\"bunny\": \"3f800000\"}")
+
+    -- invalid manifest file, file does not exist
+    -- store original pre mock
+    old_print = _G["print"]
+    old_self = self
+    old_error = _G["error"]
+
+    -- mock
+    _G["print"] = mock_print
+    self = mock_self_node
+    _G["error"] = mock_error
+
+    local result = cryptoutils.read_manifest_file(dir, file)
+
+    -- reset mock
+    _G["print"] = old_print
+    self = old_self
+    _G["error"] = old_error
+
+    assert_equal(result, "")
 end
 
 function cryptomatte_test_decode_manifest()

--- a/fusion/Modules/Lua/test_cryptomatte_utilities.lua
+++ b/fusion/Modules/Lua/test_cryptomatte_utilities.lua
@@ -318,7 +318,8 @@ function cryptomatte_test_read_manifest_file()
 end
 
 function cryptomatte_test_decode_manifest()
-    -- TODO
+    local result = cryptoutils.decode_manifest("{\"bunny\": \"3f800000\"}")
+    assert_equal(result, {bunny="3f800000"})
 end
 
 function cryptomatte_test_get_matte_names()

--- a/fusion/Modules/Lua/test_cryptomatte_utilities.lua
+++ b/fusion/Modules/Lua/test_cryptomatte_utilities.lua
@@ -87,11 +87,11 @@ function mock_log_level_unset()
     return nil
 end
 
-function mock_log_level_none()
+function mock_log_level_error()
     return "0"
 end
 
-function mock_log_level_error()
+function mock_log_level_warning()
     return "1"
 end
 
@@ -99,16 +99,19 @@ function mock_log_level_info()
     return "2"
 end
 
+function mock_node()
+    return {Name="NODE1"}
+end
+
 -- tests
 module = {}
 
-function module.test__log()
-    old_print = print
-    print = mock_print
-    cryptoutils._log("LEVEL", "MESSAGE")
-    print = old_print
-
-    assert_equal(storage["print_return"], "[Cryptomatte][LEVEL] MESSAGE")
+function module.test__format_log()
+    old_self = self
+    self = mock_node()
+    local result = cryptoutils._format_log("LEVEL", "MESSAGE")
+    self = old_self
+    assert_equal(result, "[Cryptomatte][NODE1][LEVEL] MESSAGE")
 end
 
 function module.test__get_log_level()
@@ -118,9 +121,9 @@ function module.test__get_log_level()
     os.getenv = mock_log_level_unset
     local r1 = cryptoutils._get_log_level()
     os.getenv = old_get_env
-    assert_equal(r1, 1)
+    assert_equal(r1, 0)
 
-    -- mock log level set in environment (string -> number cast)
+    -- mock log level info set in environment (string -> number cast)
     os.getenv = mock_log_level_info
     local r2 = cryptoutils._get_log_level()
     os.getenv = old_get_env
@@ -216,10 +219,6 @@ function module.test_decode_manifest()
 end
 
 function module.test_get_matte_names()
-    -- TODO
-end
-
-function module.test_get_screen_matte_name()
     -- TODO
 end
 


### PR DESCRIPTION
# Major Refactor

This refactor was done for three main reasons:
1. Improving maintainability
2. Improving stability
3. Improving performance

With these three topics covered, I strongly believe known bugs and future improvements can happen quicker and easier than before.

## Features
- log level from environment (`CRYPTOMATTE_LOG_LEVEL`)
- error, warning & info logging

## Improvements
- remove `CryptomatteInfo` metatable
- matte image creation performance
- preview image creation performance
- add/remove/toggle matte from GUI performance
- use builtin separator
- logging
- error handling