### PR TITLE
#12: Test Suite

### DIFF
--- a/fusion/Modules/Lua/test_cryptomatte_utilities.lua
+++ b/fusion/Modules/Lua/test_cryptomatte_utilities.lua
@@ -202,6 +202,10 @@ function module.test_log_error()
     -- TODO
 end
 
+function module.test_log_warning()
+    -- TODO
+end
+
 function module.test_log_info()
     -- TODO
 end

--- a/fusion/Modules/Lua/test_cryptomatte_utilities.lua
+++ b/fusion/Modules/Lua/test_cryptomatte_utilities.lua
@@ -79,8 +79,9 @@ end
 
 -- mock funtions
 storage = {}
-function mock_print(msg)
-    storage["print_return"] = msg
+
+function mock_print(message)
+    storage["print_return"] = message
 end
 
 function mock_log_level_unset()
@@ -99,7 +100,7 @@ function mock_log_level_info()
     return "2"
 end
 
-function mock_node()
+function mock_self_node()
     return {Name="NODE1"}
 end
 
@@ -107,11 +108,10 @@ end
 module = {}
 
 function module.test__format_log()
-    old_self = self
-    self = mock_node()
-    local result = cryptoutils._format_log("LEVEL", "MESSAGE")
+    local old_self = self
+    self = mock_self_node()
+    assert_equal(cryptoutils._format_log("LEVEL", "MESSAGE"), "[Cryptomatte][NODE1][LEVEL] MESSAGE")
     self = old_self
-    assert_equal(result, "[Cryptomatte][NODE1][LEVEL] MESSAGE")
 end
 
 function module.test__get_log_level()

--- a/fusion/Modules/Lua/test_cryptomatte_utilities.lua
+++ b/fusion/Modules/Lua/test_cryptomatte_utilities.lua
@@ -229,19 +229,28 @@ function cryptomatte_test_log_warning()
     old_self = self
     old_print = _G["print"]
 
-    -- mock
+    -- mock with matching log level
     _G["os"]['getenv'] = mock_log_level_warning
     self = mock_self_node()
     _G["print"] = mock_print
 
     cryptoutils.log_warning("HELP")
+    local pr1 = storage["print_return"]
+    storage["print_return"] = nil  -- clear print result for next run
+
+    -- mock with non matching log level
+    _G["os"]['getenv'] = mock_log_level_unset
+
+    cryptoutils.log_warning("HELP")
+    local pr2 = storage["print_return"]
 
     -- reset mock
     _G["os"]["getenv"] = old_get_env
     self = old_self
     _G["print"] = old_print
 
-    assert_equal(storage["print_return"], "[Cryptomatte][NODE1][WARNING] HELP")
+    assert_equal(pr1, "[Cryptomatte][NODE1][WARNING] HELP")
+    assert_equal(pr2, nil)  -- never got called
 end
 
 function cryptomatte_test_log_info()
@@ -256,13 +265,22 @@ function cryptomatte_test_log_info()
     _G["print"] = mock_print
 
     cryptoutils.log_info("HELP")
+    local pr1 = storage["print_return"]
+    storage["print_return"] = nil  -- clear print result for next run
+
+    -- mock with non matching log level
+    _G["os"]['getenv'] = mock_log_level_unset
+
+    cryptoutils.log_info("HELP")
+    local pr2 = storage["print_return"]
 
     -- reset mock
     _G["os"]["getenv"] = old_get_env
     self = old_self
     _G["print"] = old_print
 
-    assert_equal(storage["print_return"], "[Cryptomatte][NODE1][INFO] HELP")
+    assert_equal(pr1, "[Cryptomatte][NODE1][INFO] HELP")
+    assert_equal(pr2, nil)  -- never got called
 end
 
 function cryptomatte_test_get_cryptomatte_metadata()

--- a/fusion/Modules/Lua/test_cryptomatte_utilities.lua
+++ b/fusion/Modules/Lua/test_cryptomatte_utilities.lua
@@ -79,7 +79,7 @@ function assert_equal(x, y)
     if _x == _y then
         return true
     else
-        error(string.format("%s\nassertion failed: %s != %s", debug.traceback(), x, y))
+        error(string.format("%s\nassertion failed: %s != %s", debug.traceback(), _x, _y))
     end
 end
 
@@ -343,6 +343,12 @@ function cryptomatte_test_get_matte_names()
     expected["b u n n y"] = true
     assert_equal(result, expected)
 
+    -- valid name string with special characters
+    result = cryptoutils.get_matte_names("\"bunny?!\"")
+    expected = {}
+    expected["bunny?!"] = true
+    assert_equal(result, expected)
+
     -- valid name string with latin encoding characters
     result = cryptoutils.get_matte_names("\"itsabunnyé\"")
     expected = {}
@@ -365,12 +371,14 @@ function cryptomatte_test_get_matte_names()
     _G["print"] = mock_print
 
     local no_quotes = cryptoutils.get_matte_names("bunny")
+    local comma = cryptoutils.get_matte_names("bu,nny")
 
     -- reset mock
     self = old_self
     _G["print"] = old_print
 
     assert_equal(no_quotes, {})
+    assert_equal(comma, {})
 end
 
 run_tests()

--- a/fusion/Modules/Lua/test_cryptomatte_utilities.lua
+++ b/fusion/Modules/Lua/test_cryptomatte_utilities.lua
@@ -43,16 +43,29 @@ function run_tests()
     local ntests = #tests
     print(string.format("detected %s test(s) ...", ntests))
 
+    print("running tests ...")
     local count = 0
     for _, name in ipairs(tests) do
         count = count + 1
+
+        -- build progess percentage
         local percentage = (count / ntests) * 100
         local percentage_str = string.format("%.0f%%", percentage)
         local padding = string.rep(" ", 4 - string.len(percentage_str))
         percentage_str = string.format("%s%s", padding, percentage_str)
+
+        -- build test report
         local report = string.format("[%s] %s ... ", percentage_str, name)
 
+        -- add leading spaces to allign results
+        while report:len() < 60 do
+            report = report.." "
+        end
+
+        -- safe call test function
         local status, err = pcall(_G[name])
+
+        -- error handling & final report update
         if status then
             report = string.format("%s [%s]", report, "OK")
         else

--- a/fusion/Modules/Lua/test_cryptomatte_utilities.lua
+++ b/fusion/Modules/Lua/test_cryptomatte_utilities.lua
@@ -310,7 +310,33 @@ function cryptomatte_test_log_info()
 end
 
 function cryptomatte_test_get_cryptomatte_metadata()
-    -- TODO
+    local metadata = {}
+    metadata["cryptomatte/123456/conversion"] = "uint32_to_float32"
+    metadata["cryptomatte/123456/hash"] = "MurmurHash3_32"
+    metadata["cryptomatte/123456/manifest"] = "{\"bunny\": \"3f800000\"}"
+    metadata["cryptomatte/123456/name"] = "Layer"
+    metadata["Filename"] = "/tmp/foo"
+
+    local result = cryptoutils.get_cryptomatte_metadata(metadata)
+    local expected = {}
+    expected["path"] = "/tmp/foo"
+    expected["layer_count"] = 1
+    expected["id_to_name"] = {}
+    expected["id_to_name"]["123456"]="Layer"
+    expected["name_to_id"] = {}
+    expected["name_to_id"]["Layer"] = "123456"
+    expected["index_to_id"] = {}
+    expected["index_to_id"]["123456"] = 1
+    expected["id_to_index"] = {}
+    expected["id_to_index"]["1"] = "123456"
+    expected["layers"] = {}
+    expected["layers"]["123456"] = {}
+    expected["layers"]["123456"]["conversion"] = "uint32_to_float32"
+    expected["layers"]["123456"]["hash"] = "MurmurHash3_32"
+    expected["layers"]["123456"]["manifest"] = "{\"bunny\": \"3f800000\"}"
+    expected["layers"]["123456"]["name"] = "Layer"
+
+    assert_equal(result, expected)
 end
 
 function cryptomatte_test_read_manifest_file()

--- a/fusion/Modules/Lua/test_cryptomatte_utilities.lua
+++ b/fusion/Modules/Lua/test_cryptomatte_utilities.lua
@@ -10,20 +10,17 @@ Version    : 1.2.8
 local cryptoutils = require("cryptomatte_utilities")
 
 -- utils
-function collect_tests(module)
+function collect_tests()
     --[[
     Returns function names detected as test.
 
     Functions with names starting with "test_" will be picked up.
 
-    :param module: Module to collect test function names of.
-    :type module: table[string, function]
-
     :rtype: table[stri]
     ]]
     local tests = {}
-    local substr = "test_"
-    for name, _ in pairs(module) do
+    local substr = "cryptomatte_test_"
+    for name, _ in pairs(_G) do
         if string.sub(name, 1, string.len(substr)) == substr then
             table.insert(tests, name)
         end
@@ -32,7 +29,7 @@ function collect_tests(module)
     return tests
 end
 
-function run_tests(module)
+function run_tests()
     --[[
     Detects and runs all test functions of a module.
 
@@ -41,7 +38,7 @@ function run_tests(module)
     ]]
     -- collect all tests from module
     print("collectings test(s) ...")
-    local tests = collect_tests(module)
+    local tests = collect_tests()
     local ntests = #tests
     print(string.format("detected %s test(s) ...", ntests))
 
@@ -54,7 +51,7 @@ function run_tests(module)
         percentage_str = string.format("%s%s", padding, percentage_str)
         local report = string.format("[%s] %s ... ", percentage_str, name)
 
-        local status, err = pcall(module[name])
+        local status, err = pcall(_G[name])
         if status then
             report = string.format("%s [%s]", report, "OK")
         else
@@ -79,6 +76,10 @@ end
 
 -- mock funtions
 storage = {}
+
+function mock_error(message)
+    storage["error_return"] = message
+end
 
 function mock_print(message)
     storage["print_return"] = message
@@ -105,42 +106,41 @@ function mock_self_node()
 end
 
 -- tests
-module = {}
-
-function module.test__format_log()
+function cryptomatte_test__format_log()
     local old_self = self
     self = mock_self_node()
     assert_equal(cryptoutils._format_log("LEVEL", "MESSAGE"), "[Cryptomatte][NODE1][LEVEL] MESSAGE")
     self = old_self
 end
 
-function module.test__get_log_level()
-    old_get_env = os.getenv
+function cryptomatte_test__get_log_level()
+    -- store original function pre mock
+    old_get_env = _G["os"]["getenv"]
 
     -- mock log level not set in environment
-    os.getenv = mock_log_level_unset
+    _G["os"]["getenv"] = mock_log_level_unset
     local r1 = cryptoutils._get_log_level()
-    os.getenv = old_get_env
+    _G["os"]["getenv"] = old_get_env
     assert_equal(r1, 0)
 
     -- mock log level info set in environment (string -> number cast)
-    os.getenv = mock_log_level_info
+    _G["os"]["getenv"] = mock_log_level_info
     local r2 = cryptoutils._get_log_level()
-    os.getenv = old_get_env
+    _G["os"]["getenv"] = old_get_env
     assert_equal(r2, 2)
 end
 
-function module.test__string_starts_with()
+function cryptomatte_test__string_starts_with()
     assert_equal(cryptoutils._string_starts_with("foo_bar", "foo_"), true)
     assert_equal(cryptoutils._string_starts_with("foo_bar", "bar"), false)
 end
 
-function module.test__string_ends_with()
+function cryptomatte_test__string_ends_with()
     assert_equal(cryptoutils._string_ends_with("foo_bar", "_bar"), true)
     assert_equal(cryptoutils._string_ends_with("foo_bar", "foo"), false)
 end
 
-function module.test__string_split()
+function cryptomatte_test__string_split()
     result = cryptoutils._string_split("foo, bar,bunny", "([^,]+),?%s*")
     assert_equal(#result, 3)
     expected = {"foo", "bar", "bunny"}
@@ -149,7 +149,7 @@ function module.test__string_split()
     end
 end
 
-function module.test__solve_channel_name()
+function cryptomatte_test__solve_channel_name()
     -- r
     assert_equal(cryptoutils._solve_channel_name("r"), "r")
     assert_equal(cryptoutils._solve_channel_name("R"), "r")
@@ -175,17 +175,17 @@ function module.test__solve_channel_name()
     assert_equal(cryptoutils._solve_channel_name("ALPHA"), "a")
 end
 
-function module.test__get_channel_hierarchy()
+function cryptomatte_test__get_channel_hierarchy()
     -- TODO
 end
 
-function module.test__get_absolute_position()
+function cryptomatte_test__get_absolute_position()
     local x, y = cryptoutils._get_absolute_position(10, 10, 0.5, 0.5)
     assert_equal(x, 5)
     assert_equal(y, 5)
 end
 
-function module.test__is_position_in_rect()
+function cryptomatte_test__is_position_in_rect()
     -- NOTE: fusion rectangles follow mathematical convention, (origin=left,bottom)
     local rect = {left=0, top=10, right=10, bottom=0}
     assert_equal(cryptoutils._is_position_in_rect(rect, 5, 5), true)
@@ -193,37 +193,92 @@ function module.test__is_position_in_rect()
     assert_equal(cryptoutils._is_position_in_rect(rect, 5, 12), false)
 end
 
-function module.test__hex_to_float()
+function cryptomatte_test__hex_to_float()
     assert_equal(cryptoutils._hex_to_float("3f800000"), 1.0)
     assert_equal(cryptoutils._hex_to_float("bf800000"), -1.0)
 end
 
-function module.test_log_error()
+function cryptomatte_test_log_error()
+    -- store original pre mock
+    old_get_env = _G["os"]["getenv"]
+    old_self = self
+    old_print = _G["print"]
+    old_error = _G["error"]
+
+    -- mock
+    _G["os"]['getenv'] = mock_log_level_error
+    self = mock_self_node()
+    _G["print"] = mock_print
+    _G["error"] = mock_error
+
+    cryptoutils.log_error("HELP")
+
+    -- reset mock
+    _G["os"]["getenv"] = old_get_env
+    self = old_self
+    _G["print"] = old_print
+    _G["error"] = old_error
+
+    assert_equal(storage["print_return"], "[Cryptomatte][NODE1][ERROR] HELP")
+    assert_equal(storage["error_return"], "ERROR")
+end
+
+function cryptomatte_test_log_warning()
+    -- store original pre mock
+    old_get_env = _G["os"]["getenv"]
+    old_self = self
+    old_print = _G["print"]
+
+    -- mock
+    _G["os"]['getenv'] = mock_log_level_warning
+    self = mock_self_node()
+    _G["print"] = mock_print
+
+    cryptoutils.log_warning("HELP")
+
+    -- reset mock
+    _G["os"]["getenv"] = old_get_env
+    self = old_self
+    _G["print"] = old_print
+
+    assert_equal(storage["print_return"], "[Cryptomatte][NODE1][WARNING] HELP")
+end
+
+function cryptomatte_test_log_info()
+    -- store original pre mock
+    old_get_env = _G["os"]["getenv"]
+    old_self = self
+    old_print = _G["print"]
+
+    -- mock
+    _G["os"]['getenv'] = mock_log_level_info
+    self = mock_self_node()
+    _G["print"] = mock_print
+
+    cryptoutils.log_info("HELP")
+
+    -- reset mock
+    _G["os"]["getenv"] = old_get_env
+    self = old_self
+    _G["print"] = old_print
+
+    assert_equal(storage["print_return"], "[Cryptomatte][NODE1][INFO] HELP")
+end
+
+function cryptomatte_test_get_cryptomatte_metadata()
     -- TODO
 end
 
-function module.test_log_warning()
+function cryptomatte_test_read_manifest_file()
     -- TODO
 end
 
-function module.test_log_info()
+function cryptomatte_test_decode_manifest()
     -- TODO
 end
 
-function module.test_get_cryptomatte_metadata()
+function cryptomatte_test_get_matte_names()
     -- TODO
 end
 
-function module.test_read_manifest_file()
-    -- TODO
-end
-
-function module.test_decode_manifest()
-    -- TODO
-end
-
-function module.test_get_matte_names()
-    -- TODO
-end
-
-run_tests(module)
+run_tests()

--- a/fusion/Modules/Lua/test_cryptomatte_utilities.lua
+++ b/fusion/Modules/Lua/test_cryptomatte_utilities.lua
@@ -1,0 +1,226 @@
+--[[
+Requires   : Fusion 9.0.2+
+Optional   : cjson
+Created by : Cédric Duriau         [duriau.cedric@live.be]
+             Kristof Indeherberge  [xmnr0x23@gmail.com]
+             Andrew Hazelden       [andrew@andrewhazelden.com]
+Version    : 1.2.8
+--]]
+
+local cryptoutils = require("cryptomatte_utilities")
+
+-- utils
+function collect_tests(module)
+    --[[
+    Returns function names detected as test.
+
+    Functions with names starting with "test_" will be picked up.
+
+    :param module: Module to collect test function names of.
+    :type module: table[string, function]
+
+    :rtype: table[stri]
+    ]]
+    local tests = {}
+    local substr = "test_"
+    for name, _ in pairs(module) do
+        if string.sub(name, 1, string.len(substr)) == substr then
+            table.insert(tests, name)
+        end
+    end
+    table.sort(tests)
+    return tests
+end
+
+function run_tests(module)
+    --[[
+    Detects and runs all test functions of a module.
+
+    :param module: Module to run all tests for.
+    :type module: table[string, function]
+    ]]
+    -- collect all tests from module
+    print("collectings test(s) ...")
+    local tests = collect_tests(module)
+    local ntests = #tests
+    print(string.format("detected %s test(s) ...", ntests))
+
+    local count = 0
+    for _, name in ipairs(tests) do
+        count = count + 1
+        local percentage = (count / ntests) * 100
+        local percentage_str = string.format("%.0f%%", percentage)
+        local padding = string.rep(" ", 4 - string.len(percentage_str))
+        percentage_str = string.format("%s%s", padding, percentage_str)
+        local report = string.format("[%s] %s ... ", percentage_str, name)
+
+        local status, err = pcall(module[name])
+        if status then
+            report = string.format("%s [%s]", report, "OK")
+        else
+            report = string.format("%s [%s]\n%s", report, "FAILED", err)
+        end
+        print(report)
+    end
+end
+
+function assert_equal(x, y)
+    --[[
+    Tests the equality of two variables.
+
+    :rtype: boolean
+    ]]
+    if x == y then
+        return true
+    else
+        error(string.format("%s\nassertion failed: %s != %s", debug.traceback(), x, y))
+    end
+end
+
+-- mock funtions
+storage = {}
+function mock_print(msg)
+    storage["print_return"] = msg
+end
+
+function mock_log_level_unset()
+    return nil
+end
+
+function mock_log_level_none()
+    return "0"
+end
+
+function mock_log_level_error()
+    return "1"
+end
+
+function mock_log_level_info()
+    return "2"
+end
+
+-- tests
+module = {}
+
+function module.test__log()
+    old_print = print
+    print = mock_print
+    cryptoutils._log("LEVEL", "MESSAGE")
+    print = old_print
+
+    assert_equal(storage["print_return"], "[Cryptomatte][LEVEL] MESSAGE")
+end
+
+function module.test__get_log_level()
+    old_get_env = os.getenv
+
+    -- mock log level not set in environment
+    os.getenv = mock_log_level_unset
+    local r1 = cryptoutils._get_log_level()
+    os.getenv = old_get_env
+    assert_equal(r1, 1)
+
+    -- mock log level set in environment (string -> number cast)
+    os.getenv = mock_log_level_info
+    local r2 = cryptoutils._get_log_level()
+    os.getenv = old_get_env
+    assert_equal(r2, 2)
+end
+
+function module.test__string_starts_with()
+    assert_equal(cryptoutils._string_starts_with("foo_bar", "foo_"), true)
+    assert_equal(cryptoutils._string_starts_with("foo_bar", "bar"), false)
+end
+
+function module.test__string_ends_with()
+    assert_equal(cryptoutils._string_ends_with("foo_bar", "_bar"), true)
+    assert_equal(cryptoutils._string_ends_with("foo_bar", "foo"), false)
+end
+
+function module.test__string_split()
+    result = cryptoutils._string_split("foo, bar,bunny", "([^,]+),?%s*")
+    assert_equal(#result, 3)
+    expected = {"foo", "bar", "bunny"}
+    for i, v in ipairs(result) do
+        assert_equal(v, expected[i])
+    end
+end
+
+function module.test__solve_channel_name()
+    -- r
+    assert_equal(cryptoutils._solve_channel_name("r"), "r")
+    assert_equal(cryptoutils._solve_channel_name("R"), "r")
+    assert_equal(cryptoutils._solve_channel_name("red"), "r")
+    assert_equal(cryptoutils._solve_channel_name("RED"), "r")
+
+    -- g
+    assert_equal(cryptoutils._solve_channel_name("g"), "g")
+    assert_equal(cryptoutils._solve_channel_name("G"), "g")
+    assert_equal(cryptoutils._solve_channel_name("green"), "g")
+    assert_equal(cryptoutils._solve_channel_name("GREEN"), "g")
+
+    -- b
+    assert_equal(cryptoutils._solve_channel_name("b"), "b")
+    assert_equal(cryptoutils._solve_channel_name("B"), "b")
+    assert_equal(cryptoutils._solve_channel_name("blue"), "b")
+    assert_equal(cryptoutils._solve_channel_name("BLUE"), "b")
+
+    -- a
+    assert_equal(cryptoutils._solve_channel_name("a"), "a")
+    assert_equal(cryptoutils._solve_channel_name("A"), "a")
+    assert_equal(cryptoutils._solve_channel_name("alpha"), "a")
+    assert_equal(cryptoutils._solve_channel_name("ALPHA"), "a")
+end
+
+function module.test__get_channel_hierarchy()
+    -- TODO
+end
+
+function module.test__get_absolute_position()
+    local x, y = cryptoutils._get_absolute_position(10, 10, 0.5, 0.5)
+    assert_equal(x, 5)
+    assert_equal(y, 5)
+end
+
+function module.test__is_position_in_rect()
+    -- NOTE: fusion rectangles follow mathematical convention, (origin=left,bottom)
+    local rect = {left=0, top=10, right=10, bottom=0}
+    assert_equal(cryptoutils._is_position_in_rect(rect, 5, 5), true)
+    assert_equal(cryptoutils._is_position_in_rect(rect, 12, 5), false)
+    assert_equal(cryptoutils._is_position_in_rect(rect, 5, 12), false)
+end
+
+function module.test__hex_to_float()
+    assert_equal(cryptoutils._hex_to_float("3f800000"), 1.0)
+    assert_equal(cryptoutils._hex_to_float("bf800000"), -1.0)
+end
+
+function module.test_log_error()
+    -- TODO
+end
+
+function module.test_log_info()
+    -- TODO
+end
+
+function module.test_get_cryptomatte_metadata()
+    -- TODO
+end
+
+function module.test_read_manifest_file()
+    -- TODO
+end
+
+function module.test_decode_manifest()
+    -- TODO
+end
+
+function module.test_get_matte_names()
+    -- TODO
+end
+
+function module.test_get_screen_matte_name()
+    -- TODO
+end
+
+run_tests(module)

--- a/fusion/Modules/Lua/test_cryptomatte_utilities.lua
+++ b/fusion/Modules/Lua/test_cryptomatte_utilities.lua
@@ -314,7 +314,36 @@ function cryptomatte_test_get_cryptomatte_metadata()
 end
 
 function cryptomatte_test_read_manifest_file()
-    -- TODO
+    -- valid manifest file
+    local tmp_file = os.tmpname()
+    local fp = io.open(tmp_file, "w")
+    fp:write("{\"bunny\": \"3f800000\"}")
+    fp:close()
+
+    local dir, file = string.match(tmp_file, "(.-)([^\\/]-%.?[^%.\\/]*)$")
+    local result = cryptoutils.read_manifest_file(dir, file)
+    os.remove(tmp_file)
+    assert_equal(result, "{\"bunny\": \"3f800000\"}")
+
+    -- invalid manifest file, file does not exist
+    -- store original pre mock
+    old_print = _G["print"]
+    old_self = self
+    old_error = _G["error"]
+
+    -- mock
+    _G["print"] = mock_print
+    self = mock_self_node
+    _G["error"] = mock_error
+
+    local result = cryptoutils.read_manifest_file(dir, file)
+
+    -- reset mock
+    _G["print"] = old_print
+    self = old_self
+    _G["error"] = old_error
+
+    assert_equal(result, "")
 end
 
 function cryptomatte_test_decode_manifest()

--- a/fusion/Modules/Lua/test_cryptomatte_utilities.lua
+++ b/fusion/Modules/Lua/test_cryptomatte_utilities.lua
@@ -318,7 +318,8 @@ function cryptomatte_test_read_manifest_file()
 end
 
 function cryptomatte_test_decode_manifest()
-    -- TODO
+    local result = cryptoutils.decode_manifest("{\"bunny\": \"3f800000\"}")
+    assert_equal(result, {bunny="3f800000"})
 end
 
 function cryptomatte_test_get_matte_names()

--- a/fusion/Modules/Lua/test_cryptomatte_utilities.lua
+++ b/fusion/Modules/Lua/test_cryptomatte_utilities.lua
@@ -87,11 +87,11 @@ function mock_log_level_unset()
     return nil
 end
 
-function mock_log_level_none()
+function mock_log_level_error()
     return "0"
 end
 
-function mock_log_level_error()
+function mock_log_level_warning()
     return "1"
 end
 
@@ -99,16 +99,19 @@ function mock_log_level_info()
     return "2"
 end
 
+function mock_node()
+    return {Name="NODE1"}
+end
+
 -- tests
 module = {}
 
-function module.test__log()
-    old_print = print
-    print = mock_print
-    cryptoutils._log("LEVEL", "MESSAGE")
-    print = old_print
-
-    assert_equal(storage["print_return"], "[Cryptomatte][LEVEL] MESSAGE")
+function module.test__format_log()
+    old_self = self
+    self = mock_node()
+    local result = cryptoutils._format_log("LEVEL", "MESSAGE")
+    self = old_self
+    assert_equal(result, "[Cryptomatte][NODE1][LEVEL] MESSAGE")
 end
 
 function module.test__get_log_level()
@@ -118,9 +121,9 @@ function module.test__get_log_level()
     os.getenv = mock_log_level_unset
     local r1 = cryptoutils._get_log_level()
     os.getenv = old_get_env
-    assert_equal(r1, 1)
+    assert_equal(r1, 0)
 
-    -- mock log level set in environment (string -> number cast)
+    -- mock log level info set in environment (string -> number cast)
     os.getenv = mock_log_level_info
     local r2 = cryptoutils._get_log_level()
     os.getenv = old_get_env
@@ -216,10 +219,6 @@ function module.test_decode_manifest()
 end
 
 function module.test_get_matte_names()
-    -- TODO
-end
-
-function module.test_get_screen_matte_name()
     -- TODO
 end
 


### PR DESCRIPTION
Fixes #12

## Changes
- implement test suite for `cryptomatte_utilities` lua module

## Example
```lua
Lua> dofile("/home/cduriau/repo/Cryptomatte/fusion/Modules/Lua/test_cryptomatte_utilities.lua")
collectings test(s) ...
detected 17 test(s) ...
running tests ...
[  6%] cryptomatte_test__format_log ...                      [OK]
[ 12%] cryptomatte_test__get_absolute_position ...           [OK]
[ 18%] cryptomatte_test__get_channel_hierarchy ...           [OK]
[ 24%] cryptomatte_test__get_log_level ...                   [OK]
[ 29%] cryptomatte_test__hex_to_float ...                    [OK]
[ 35%] cryptomatte_test__is_position_in_rect ...             [OK]
[ 41%] cryptomatte_test__solve_channel_name ...              [OK]
[ 47%] cryptomatte_test__string_ends_with ...                [OK]
[ 53%] cryptomatte_test__string_split ...                    [OK]
[ 59%] cryptomatte_test__string_starts_with ...              [OK]
[ 65%] cryptomatte_test_decode_manifest ...                  [OK]
[ 71%] cryptomatte_test_get_cryptomatte_metadata ...         [OK]
[ 76%] cryptomatte_test_get_matte_names ...                  [OK]
[ 82%] cryptomatte_test_log_error ...                        [OK]
[ 88%] cryptomatte_test_log_info ...                         [OK]
[ 94%] cryptomatte_test_log_warning ...                      [OK]
[100%] cryptomatte_test_read_manifest_file ...               [OK]
```