### PR TITLE
#60: fix test for darwin

### DIFF
--- a/fusion/Modules/Lua/test_cryptomatte_utilities.lua
+++ b/fusion/Modules/Lua/test_cryptomatte_utilities.lua
@@ -191,21 +191,15 @@ function cryptomatte_test__get_absolute_path()
 
     assert_equal(r1, "/tmp/test.exr")
     assert_equal(r2, "C:/Temp/test.exr")
-    local pathsep = package.config:sub(1,1)
-    if pathsep == "/" then
-        local tmp_dir = os.getenv("TMPDIR")
-        local format_str = ""
-        if tmp_dir == "/tmp" then
-            -- linux
-            format_str = "%s/%s"
-        else
-            -- darwin
-            format_str = "%s%s"
-        end
-        local abs_tmp_path = string.format(format_str, tmp_dir, "test.exr")
-        assert_equal(r3, abs_tmp_path)
-    else
+
+    if jit.os == "Windows" then
         assert_equal(r3, "C:\\Temp\\test.exr")
+    elseif jit.os == "Linux" then
+        assert_equal(r3, "/tmp/test.exr")
+    elseif jit.os == "OSX" then
+        local tmp_dir = os.getenv("TMPDIR")
+        local abs_tmp_path = string.format("%s%s", tmp_dir, "test.exr")
+        assert_equal(r3, abs_tmp_path)
     end
 end
 

--- a/fusion/Modules/Lua/test_cryptomatte_utilities.lua
+++ b/fusion/Modules/Lua/test_cryptomatte_utilities.lua
@@ -194,7 +194,6 @@ function cryptomatte_test__get_absolute_path()
     local pathsep = package.config:sub(1,1)
     if pathsep == "/" then
         local tmp_dir = os.getenv("TMPDIR")
-        local abs_tmp_path = ""
         local format_str = ""
         if tmp_dir == "/tmp" then
             -- linux
@@ -203,7 +202,7 @@ function cryptomatte_test__get_absolute_path()
             -- darwin
             format_str = "%s%s"
         end
-        abs_tmp_path = string.format(format_str, tmp_dir, "test.exr")
+        local abs_tmp_path = string.format(format_str, tmp_dir, "test.exr")
         assert_equal(r3, abs_tmp_path)
     else
         assert_equal(r3, "C:\\Temp\\test.exr")

--- a/fusion/Modules/Lua/test_cryptomatte_utilities.lua
+++ b/fusion/Modules/Lua/test_cryptomatte_utilities.lua
@@ -193,7 +193,18 @@ function cryptomatte_test__get_absolute_path()
     assert_equal(r2, "C:/Temp/test.exr")
     local pathsep = package.config:sub(1,1)
     if pathsep == "/" then
-        assert_equal(r3, "/tmp/test.exr")
+        local tmp_dir = os.getenv("TMPDIR")
+        local abs_tmp_path = ""
+        local format_str = ""
+        if tmp_dir == "/tmp" then
+            -- linux
+            format_str = "%s/%s"
+        else
+            -- darwin
+            format_str = "%s%s"
+        end
+        abs_tmp_path = string.format(format_str, tmp_dir, "test.exr")
+        assert_equal(r3, abs_tmp_path)
     else
         assert_equal(r3, "C:\\Temp\\test.exr")
     end


### PR DESCRIPTION
Fixes #60 

## Description
When running the test suite on darwin, on test fails related to the path mapping of the temp directory of the platform. It is currently being assumed all systems with `/` paths have `Temp:` mapped to `/tmp` which is not true for darwin.

## Changes
- fix `cryptomatte_test__get_absolute_path` test to support darwin